### PR TITLE
Doc/fix requirements

### DIFF
--- a/auv/requirements.txt
+++ b/auv/requirements.txt
@@ -12,4 +12,4 @@ pyserial==3.5
 setuptools==59.6.0
 smbus==1.1.post2
 spidev==3.6
-# torch==2.5.1 used in depth cam but also 1GB so install when needed
+torch==2.5.1 used in depth cam but also 1GB so install when needed

--- a/auv/requirements.txt
+++ b/auv/requirements.txt
@@ -1,5 +1,6 @@
 Adafruit_BBIO==1.2.0
 Adafruit_PureIO==1.1.11
+Adafruit_PureIO==1.1.11
 Flask==3.0.3
 mock==5.1.0
 numpy==2.1.2
@@ -12,4 +13,4 @@ pyserial==3.5
 setuptools==59.6.0
 smbus==1.1.post2
 spidev==3.6
-torch==2.5.1 used in depth cam but also 1GB so install when needed
+# torch==2.5.1 used in depth cam but also 1GB so add as needed

--- a/auv/requirements.txt
+++ b/auv/requirements.txt
@@ -1,11 +1,15 @@
 Adafruit_BBIO==1.2.0
-adafruit_circuitpython_gps==3.10.6
-Adafruit_PureIO==1.1.9
-mock==4.0.3
+Adafruit_PureIO==1.1.11
+Flask==3.0.3
+mock==5.1.0
+numpy==2.1.2
 pigpio==1.78
-pip==22.3.1
+pip==22.0.2
+pynmea2==1.19.0
+pyproj==3.4.1
+pyrealsense2==2.55.1.6486
 pyserial==3.5
-setuptools==58.1.0
+setuptools==59.6.0
 smbus==1.1.post2
-soundcard==0.4.2
 spidev==3.6
+# torch==2.5.1 used in depth cam but also 1GB so install when needed

--- a/web_app/README.md
+++ b/web_app/README.md
@@ -10,7 +10,13 @@ This frontend is built with a react framework and FastAPI backend.
     - npm
     - git
     - python (3.x.x)
-    - TODO: update
+    - other pip libraries
+
+To install python dependencies, run:
+```bash
+cd web_app
+pip install -r requirements.txt
+```
 
 To install node dependencies, run:
 ```bash
@@ -19,7 +25,7 @@ npm install
 ```
 
 To startup the GUI:
-```bash
+```bashs
 sh startup.sh
 ```
 (Depending on what python version you have, you may have to edit startup.sh to be python or python3.)

--- a/web_app/requirements.txt
+++ b/web_app/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.4
+pydantic==2.9.2
+pynmea2==1.19.0
+pyserial==3.5
+uvicorn==0.32.0


### PR DESCRIPTION
closes #117 

- added requirements for webapp
- updated requirements for auv
(Note: This may be subject to change because it was not ran with the auv itself.)

-> torch in auv is commented out because it is stupid large and only invoked in the depth cam, which isn't regularly used. 