### PR TITLE
WI25 Pool Test - IMU sensor readings as a separate thread

### DIFF
--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -59,7 +59,7 @@ class IMU:
     def read_euler(self) -> tuple[float, float, float]:
         """ Return the current heading, pitch, and roll in a thread-safe manner """
         with self.lock:
-            return self.heading, self.pitch, self.roll
+            return self.roll, self.pitch, self.heading
 
     def update_imu_reading(self):
         """ Update IMU readings and compute Euler angles """
@@ -96,7 +96,7 @@ class IMU:
 
             # Update heading, pitch, and roll in a thread-safe manner
             with self.lock:
-                self.heading, self.pitch, self.roll = euler_angles
+                self.roll, self.pitch, self.heading = euler_angles
 
             self.prev_time = new_time
 

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -76,7 +76,7 @@ class IMU:
 
             new_time = time.time()
             dt = new_time - self.prev_time
-            print("Dt: ", dt)
+            # print("Dt: ", dt)
 
             # Update the AHRS algorithm with the sensor data
             self.ahrs.update(

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -43,6 +43,7 @@ class IMU:
             10,  # magnetic rejection
             5 * Rate.RATE_1_66K_HZ,  # recovery trigger period = 5 seconds
         )
+        self.prev_time = time.time() 
 
     def read_euler(self) -> tuple[float, float, float]:
         # Read sensor data
@@ -57,11 +58,14 @@ class IMU:
         corrected_gyro_x, corrected_gyro_y, corrected_gyro_z = self.offset.update(np.array([gyro_x, gyro_y, gyro_z]))
 
         # Update the AHRS algorithm with the sensor data
+        dt = time.time() - self.prev_time
+        print("dt = ", dt)
+        
         self.ahrs.update(
             np.array([corrected_gyro_x, corrected_gyro_y, corrected_gyro_z]),
             np.array([accel_x, accel_y, accel_z]),
             np.array([mag_x, mag_y, mag_z]),
-            20.0
+            dt
         )
 
         # Get the Euler angles from the AHRS algorithm
@@ -69,4 +73,6 @@ class IMU:
 
         # Return heading, pitch, and roll
         heading, pitch, roll = euler_angles
+
+        self.prev_time = time.time()
         return heading, pitch, roll

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -61,8 +61,6 @@ class IMU:
         """ Update IMU readings and compute Euler angles """
         try:
             accel_x, accel_y, accel_z = self.ag_sensor.acceleration
-            print(self.ag_sensor.gyro)
-            print(global_vars.gyro_offset_vector)
 
             gyro_x, gyro_y, gyro_z = (
                 np.array(self.ag_sensor.gyro) - np.array(global_vars.gyro_offset_vector)

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -39,7 +39,7 @@ class IMU:
         self.ahrs = imufusion.Ahrs()
 
         self.ahrs.settings = imufusion.Settings(
-            imufusion.CONVENTION_ENU,  # convention
+            imufusion.CONVENTION_NWU,  # convention
             0.5,  # gain
             2000,  # gyroscope range
             10,  # acceleration rejection

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -65,8 +65,8 @@ class IMU:
         """ Update IMU readings and compute Euler angles """
         try:
             accel_x, accel_y, accel_z = self.ag_sensor.acceleration
-            print(self.ag_sensor.gyro)
-            print(global_vars.gyro_offset_vector)
+            # print(self.ag_sensor.gyro)
+            # print(global_vars.gyro_offset_vector)
 
             gyro_x, gyro_y, gyro_z = (
                 np.array(self.ag_sensor.gyro) - np.array(global_vars.gyro_offset_vector)

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -76,6 +76,7 @@ class IMU:
 
             new_time = time.time()
             dt = new_time - self.prev_time
+            print("Dt: ", dt)
 
             # Update the AHRS algorithm with the sensor data
             self.ahrs.update(

--- a/auv/api/imu.py
+++ b/auv/api/imu.py
@@ -6,13 +6,14 @@ from adafruit_lsm6ds.lsm6dsox import LSM6DSOX as LSM6DS
 from adafruit_lis3mdl import LIS3MDL
 import imufusion
 import numpy as np
+import threading
 from static import global_vars
 
 class IMU:
     """ Utilize inheritance of the low-level parent class """
 
     def __init__(self):
-        """ Simply call our superclass constructor """
+        """ Initialize the IMU sensors and AHRS algorithm """
         super().__init__()
         i2c = board.I2C()  # uses board.SCL and board.SDA
         self.ag_sensor = LSM6DS(i2c)
@@ -33,6 +34,8 @@ class IMU:
         print("Gyro rate set to: %d HZ" % Rate.string[self.ag_sensor.gyro_data_rate])
 
         self.offset = imufusion.Offset(Rate.RATE_1_66K_HZ)
+        self.prev_time = time.time()
+
         self.ahrs = imufusion.Ahrs()
 
         self.ahrs.settings = imufusion.Settings(
@@ -43,36 +46,77 @@ class IMU:
             10,  # magnetic rejection
             5 * Rate.RATE_1_66K_HZ,  # recovery trigger period = 5 seconds
         )
-        self.prev_time = time.time() 
+
+        self.heading = 0.0
+        self.pitch = 0.0
+        self.roll = 0.0
+        self.stop_event = threading.Event()
+        self.thread = None
 
     def read_euler(self) -> tuple[float, float, float]:
-        # Read sensor data
-        accel_x, accel_y, accel_z = self.ag_sensor.acceleration
-        print(self.ag_sensor.gyro)
-        print(global_vars.gyro_offset_vector)
+        """ Return the current heading, pitch, and roll """
+        return self.heading, self.pitch, self.roll
 
-        gyro_x, gyro_y, gyro_z = np.array(self.ag_sensor.gyro) - np.array(global_vars.gyro_offset_vector)
-        mag_x, mag_y, mag_z = np.array(self.m_sensor.magnetic) - np.array(global_vars.mag_offset_vector)
+    def update_imu_reading(self):
+        """ Update IMU readings and compute Euler angles """
+        try:
+            accel_x, accel_y, accel_z = self.ag_sensor.acceleration
+            print(self.ag_sensor.gyro)
+            print(global_vars.gyro_offset_vector)
 
-        # Update the offset for sensor drift correction
-        corrected_gyro_x, corrected_gyro_y, corrected_gyro_z = self.offset.update(np.array([gyro_x, gyro_y, gyro_z]))
+            gyro_x, gyro_y, gyro_z = (
+                np.array(self.ag_sensor.gyro) - np.array(global_vars.gyro_offset_vector)
+            )
+            mag_x, mag_y, mag_z = (
+                np.array(self.m_sensor.magnetic) - np.array(global_vars.mag_offset_vector)
+            )
 
-        # Update the AHRS algorithm with the sensor data
-        dt = time.time() - self.prev_time
-        print("dt = ", dt)
-        
-        self.ahrs.update(
-            np.array([corrected_gyro_x, corrected_gyro_y, corrected_gyro_z]),
-            np.array([accel_x, accel_y, accel_z]),
-            np.array([mag_x, mag_y, mag_z]),
-            dt
-        )
+            # Update the offset for sensor drift correction
+            corrected_gyro_x, corrected_gyro_y, corrected_gyro_z = self.offset.update(
+                np.array([gyro_x, gyro_y, gyro_z])
+            )
 
-        # Get the Euler angles from the AHRS algorithm
-        euler_angles = self.ahrs.quaternion.to_euler()
+            new_time = time.time()
+            dt = new_time - self.prev_time
 
-        # Return heading, pitch, and roll
-        heading, pitch, roll = euler_angles
+            # Update the AHRS algorithm with the sensor data
+            self.ahrs.update(
+                np.array([corrected_gyro_x, corrected_gyro_y, corrected_gyro_z]),
+                np.array([accel_x, accel_y, accel_z]),
+                np.array([mag_x, mag_y, mag_z]),
+                dt,
+            )
 
-        self.prev_time = time.time()
-        return heading, pitch, roll
+            # Get the Euler angles from the AHRS algorithm
+            euler_angles = self.ahrs.quaternion.to_euler()
+
+            # Update heading, pitch, and roll
+            self.heading, self.pitch, self.roll = euler_angles
+            self.prev_time = new_time
+
+        except Exception as e:
+            print(f"Error updating IMU readings: {e}")
+
+    def start_reading(self):
+        """ Start the sensor reading in a separate thread """
+        if self.thread and self.thread.is_alive():
+            print("Sensor reading thread is already running.")
+            return
+
+        self.thread = threading.Thread(target=self._sensor_reading_loop, daemon=True)
+        self.stop_event.clear()
+        self.thread.start()
+        print("Sensor reading thread started.")
+
+    def stop_reading(self):
+        """ Stop the sensor reading thread """
+        if self.thread:
+            self.stop_event.set()
+            self.thread.join()
+            print("Sensor reading thread stopped.")
+
+    def _sensor_reading_loop(self):
+        """ Continuously update IMU readings """
+        while not self.stop_event.is_set():
+            self.update_imu_reading()
+            time.sleep(0.01)  # Adjust sleep duration as needed

--- a/auv/auv.py
+++ b/auv/auv.py
@@ -36,6 +36,7 @@ from tests import IMU_Calibration_Test
 from static import constants
 from static import global_vars
 
+imu = None
 
 def threads_active(ts):
     for t in ts:
@@ -135,6 +136,8 @@ def start_threads(ts, queue, halt):
     imu_calibration_test.start()
     if gps is not None:
         gps.start()
+    if imu is not None:
+        imu.start_reading()
 
 
 if __name__ == "__main__":  # If we are executing this file as main
@@ -149,10 +152,18 @@ if __name__ == "__main__":  # If we are executing this file as main
         while threads_active(ts):
             if global_vars.stop_all_threads:
                 global_vars.stop_all_threads = False
+
+                if imu is not None:
+                    imu.stop_reading();
+                
                 stop_threads(ts)
 
             if global_vars.restart_threads:
                 global_vars.restart_threads = False
+
+                if imu is not None:
+                    imu.stop_reading();
+                
                 stop_threads(ts)
 
                 # Reinitialize and restart all threads
@@ -165,6 +176,9 @@ if __name__ == "__main__":  # If we are executing this file as main
             time.sleep(1)
     except KeyboardInterrupt:
         # kill threads
+        if imu is not None:
+            imu.stop_reading();
+        
         for t in ts:
             if t.is_alive():
                 t.stop()

--- a/auv/tests/pid/heading_test.py
+++ b/auv/tests/pid/heading_test.py
@@ -53,7 +53,7 @@ class Heading_Test(threading.Thread):
 
     def update_motor(self, last_speed: float) -> None:
         "Update motor speed with PID control input"
-        curr_heading, roll, pitch = self.imu.read_euler()
+        roll, pitch, curr_heading = self.imu.read_euler()
         print(f"current heading = {curr_heading}\n")
         pid_output = self.heading_pid.pid(curr_heading, heading=True)
 

--- a/auv/threads/auv_receive.py
+++ b/auv/threads/auv_receive.py
@@ -372,9 +372,9 @@ class AUV_Receive(threading.Thread):
         elif test == 2:  # down
             down_speed = speed
         elif test == 3:  # left
-            turn_speed = speed
-        elif test == 4:  # right
             turn_speed = -1 * speed
+        elif test == 4:  # right
+            turn_speed = speed
 
         time_begin = time.time()
 

--- a/auv/threads/auv_receive.py
+++ b/auv/threads/auv_receive.py
@@ -656,7 +656,7 @@ class AUV_Receive(threading.Thread):
     def get_heading(self):
         if self.imu is not None:
             try:
-                heading, _, _ = self.imu.read_euler()
+                roll, pitch, heading = self.imu.read_euler()
             except:
                 print("Failed to read IMU")
             return heading - global_vars.heading_offset
@@ -667,11 +667,11 @@ class AUV_Receive(threading.Thread):
     # Does not include calibration offset
     def get_euler(self):
         try:
-            heading, roll, pitch = self.imu.read_euler()
+            roll, pitch, heading = self.imu.read_euler()
             # print('HEADING=', heading)
         except:
             # TODO print statement, something went wrong!
-            heading, roll, pitch = None, None, None
+            roll, pitch, heading = None, None, None
         return heading, roll, pitch
 
     def start_heading_test(self, set_heading=0):

--- a/auv/threads/auv_send_data.py
+++ b/auv/threads/auv_send_data.py
@@ -258,8 +258,10 @@ class AUV_Send_Data(threading.Thread):
 
     def get_heading(self):
         try:
-            heading, _, _ = self.imu.read_euler()
+            heading, roll, pitch = self.imu.read_euler()
             print("HEADING=", heading)
+            print("HEADING=", roll)
+            print("HEADING=", pitch)
             heading = heading - global_vars.heading_offset
             if heading < 0: 
                 heading += 360 

--- a/auv/threads/auv_send_data.py
+++ b/auv/threads/auv_send_data.py
@@ -258,10 +258,10 @@ class AUV_Send_Data(threading.Thread):
 
     def get_heading(self):
         try:
-            heading, roll, pitch = self.imu.read_euler()
+            roll, pitch, heading = self.imu.read_euler()
             print("HEADING=", heading)
-            print("HEADING=", roll)
-            print("HEADING=", pitch)
+            print("ROLL=", roll)
+            print("PITCH=", pitch)
             heading = heading - global_vars.heading_offset
             if heading < 0: 
                 heading += 360 


### PR DESCRIPTION
- Make IMU sensor readings into a separate thread. This is to avoid having to read from the sensors in the middle of the PID loop (hopefully to reduce delay caused by the calculations involved). 
- Seems to have helped with the PID results. The AUV was more responsive in correcting itself to the target heading. 
- We also reversed the turn motor direction and swapped a few input motor points because some wires and parts were flipped during assembly. 
